### PR TITLE
Phase7-admin-interface

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -127,27 +127,27 @@
 ### Phase 7: Admin Interface
 
 #### Test 20: Admin Authentication
-- [ ] should_require_admin_login
-- [ ] should_validate_admin_credentials
-- [ ] should_restrict_access_to_admin_pages
+- [x] should_require_admin_login
+- [x] should_validate_admin_credentials
+- [x] should_restrict_access_to_admin_pages
 
 #### Test 21: Admin User Management
-- [ ] should_display_all_users_in_admin
-- [ ] should_allow_admin_to_create_user
-- [ ] should_allow_admin_to_add_deposit
-- [ ] should_allow_admin_to_delete_user
+- [x] should_display_all_users_in_admin
+- [x] should_allow_admin_to_create_user
+- [x] should_allow_admin_to_add_deposit
+- [x] should_allow_admin_to_delete_user
 
 #### Test 22: Admin Store Management
-- [ ] should_display_all_stores_in_admin
-- [ ] should_allow_admin_to_create_store
-- [ ] should_allow_admin_to_toggle_coupon_system
-- [ ] should_allow_admin_to_set_coupon_goal
+- [x] should_display_all_stores_in_admin
+- [x] should_allow_admin_to_create_store
+- [x] should_allow_admin_to_toggle_coupon_system
+- [x] should_allow_admin_to_set_coupon_goal
 
 #### Test 23: Admin Transaction History
-- [ ] should_display_all_transactions
-- [ ] should_filter_transactions_by_user
-- [ ] should_filter_transactions_by_date
-- [ ] should_filter_transactions_by_store
+- [x] should_display_all_transactions
+- [x] should_filter_transactions_by_user
+- [x] should_filter_transactions_by_date
+- [x] should_filter_transactions_by_store
 
 ### Phase 8: Charts & Visualization
 

--- a/src/repositories/receipt_repository.py
+++ b/src/repositories/receipt_repository.py
@@ -39,3 +39,21 @@ class ReceiptRepository:
             receipt_data["id"] = doc.id
             receipts.append(receipt_data)
         return receipts
+    
+    def list_all(self) -> List[dict]:
+        docs = self.db.collection("receipts").get()
+        receipts = []
+        for doc in docs:
+            receipt_data = doc.to_dict()
+            receipt_data["id"] = doc.id
+            receipts.append(receipt_data)
+        return receipts
+    
+    def find_by_store_name(self, store_name: str) -> List[dict]:
+        docs = self.db.collection("receipts").where("store_name", "==", store_name).get()
+        receipts = []
+        for doc in docs:
+            receipt_data = doc.to_dict()
+            receipt_data["id"] = doc.id
+            receipts.append(receipt_data)
+        return receipts

--- a/src/repositories/receipt_repository.py
+++ b/src/repositories/receipt_repository.py
@@ -16,6 +16,15 @@ class ReceiptRepository:
             created_at=firestore.SERVER_TIMESTAMP,
         )
 
+        # Enrich for admin/dashboard queries that expect denormalized fields
+        try:
+            receipt_data["user_name"] = getattr(receipt.user, "name", None)
+            receipt_data["store_name"] = getattr(receipt.store, "name", None)
+            # Provide an alias for total used by some views
+            receipt_data["total_amount"] = receipt_data.get("total")
+        except Exception:
+            pass
+
         doc_ref, _ = self.db.collection("receipts").add(receipt_data)
         return doc_ref.id
     

--- a/src/repositories/store_repository.py
+++ b/src/repositories/store_repository.py
@@ -11,13 +11,21 @@ class StoreRepository:
     def save(self, store: Store):
         # Firestore .add() returns (DocumentReference, WriteResult)
         doc_ref, _ = self.firestore_client.collection(STORES_COLLECTION).add(store.to_dict())
+        # Set generated id on the domain object for downstream use
+        try:
+            store.id = doc_ref.id
+        except Exception:
+            pass
         return doc_ref.id
     
     def get_by_id(self, store_id):
         doc_ref = self.firestore_client.collection(STORES_COLLECTION).document(store_id)
         doc = doc_ref.get()
         if doc.exists:
-            return Store.from_dict(doc.to_dict())
+            store = Store.from_dict(doc.to_dict())
+            # propagate id for callers that need it
+            store.id = doc.id
+            return store
         return None
     
     def find_by_name(self, name):
@@ -28,12 +36,22 @@ class StoreRepository:
             .stream()
         )
         for doc in docs:
-            return Store.from_dict(doc.to_dict())
+            store = Store.from_dict(doc.to_dict())
+            store.id = doc.id
+            return store
         return None
     
     def list_all(self):
         docs = self.firestore_client.collection(STORES_COLLECTION).stream()
         stores = []
         for doc in docs:
-            stores.append(Store.from_dict(doc.to_dict()))
+            s = Store.from_dict(doc.to_dict())
+            s.id = doc.id
+            stores.append(s)
         return stores
+
+    def update(self, store_id: str, data: dict):
+        """Partial update of store document (merge)."""
+        doc_ref = self.firestore_client.collection(STORES_COLLECTION).document(store_id)
+        # set with merge=True updates only provided fields
+        return doc_ref.set(data, merge=True)

--- a/src/repositories/store_repository.py
+++ b/src/repositories/store_repository.py
@@ -30,3 +30,10 @@ class StoreRepository:
         for doc in docs:
             return Store.from_dict(doc.to_dict())
         return None
+    
+    def list_all(self):
+        docs = self.firestore_client.collection(STORES_COLLECTION).stream()
+        stores = []
+        for doc in docs:
+            stores.append(Store.from_dict(doc.to_dict()))
+        return stores

--- a/tests/admin/test_admin_authentication.py
+++ b/tests/admin/test_admin_authentication.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import Mock, patch
+from src.web.app import create_app
+
+
+class TestAdminAuthentication:
+    
+    @pytest.fixture
+    def client(self):
+        user_repo = Mock()
+        receipt_repo = Mock()
+        coupon_repo = Mock()
+        ocr_service = Mock()
+        store_repo = Mock()
+        coupon_service = Mock()
+        
+        app = create_app(
+            user_repo=user_repo,
+            receipt_repo=receipt_repo,
+            coupon_repo=coupon_repo,
+            ocr_service=ocr_service,
+            store_repo=store_repo,
+            coupon_service=coupon_service
+        )
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            yield client
+    
+    def test_should_require_admin_login(self, client):
+        response = client.get('/admin')
+        assert response.status_code == 302
+        assert '/admin/login' in response.headers['Location']
+    
+    def test_should_validate_admin_credentials(self, client):
+        response = client.post('/admin/login', data={
+            'username': 'admin',
+            'password': 'password'
+        })
+        assert response.status_code == 302
+        assert '/admin' in response.headers['Location']
+    
+    def test_should_restrict_access_to_admin_pages(self, client):
+        response = client.get('/admin/users')
+        assert response.status_code == 302
+        assert '/admin/login' in response.headers['Location']

--- a/tests/admin/test_admin_store_management.py
+++ b/tests/admin/test_admin_store_management.py
@@ -1,0 +1,94 @@
+import pytest
+from unittest.mock import Mock, patch
+from decimal import Decimal
+from src.web.app import create_app
+
+
+class TestAdminStoreManagement:
+    
+    @pytest.fixture
+    def client(self):
+        user_repo = Mock()
+        receipt_repo = Mock()
+        coupon_repo = Mock()
+        ocr_service = Mock()
+        self.store_repo = Mock()
+        coupon_service = Mock()
+        
+        app = create_app(
+            user_repo=user_repo,
+            receipt_repo=receipt_repo,
+            coupon_repo=coupon_repo,
+            ocr_service=ocr_service,
+            store_repo=self.store_repo,
+            coupon_service=coupon_service
+        )
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            yield client
+    
+    def test_should_display_all_stores_in_admin(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+        
+        store1 = Mock()
+        store1.name = 'Store1'
+        store1.coupon_enabled = True
+        store1.coupon_goal = 10
+        store2 = Mock()
+        store2.name = 'Store2'
+        store2.coupon_enabled = False
+        store2.coupon_goal = 5
+        self.store_repo.list_all.return_value = [store1, store2]
+        
+        response = client.get('/admin/stores')
+        assert response.status_code == 200
+        content = response.get_data(as_text=True)
+        assert 'Store1' in content
+        assert 'Store2' in content
+        assert 'True' in content
+        assert 'False' in content
+    
+    def test_should_allow_admin_to_create_store(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+        
+        response = client.post('/admin/stores', data={
+            'name': 'New Store',
+            'coupon_enabled': 'on',
+            'coupon_goal': '8'
+        })
+        assert response.status_code == 302
+        self.store_repo.save.assert_called_once()
+    
+    def test_should_allow_admin_to_toggle_coupon_system(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+            
+        store = Mock()
+        store.coupon_enabled = True
+        self.store_repo.get_by_id.return_value = store
+        
+        response = client.post('/admin/stores/store1/toggle-coupon')
+        assert response.status_code == 302
+        assert store.coupon_enabled == False
+        self.store_repo.save.assert_called_once_with(store)
+    
+    def test_should_allow_admin_to_set_coupon_goal(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+            
+        store = Mock()
+        store.coupon_goal = 10
+        self.store_repo.get_by_id.return_value = store
+        
+        response = client.post('/admin/stores/store1/set-goal', data={
+            'goal': '15'
+        })
+        assert response.status_code == 302
+        assert store.coupon_goal == 15
+        self.store_repo.save.assert_called_once_with(store)

--- a/tests/admin/test_admin_transaction_history.py
+++ b/tests/admin/test_admin_transaction_history.py
@@ -1,0 +1,105 @@
+import pytest
+from unittest.mock import Mock, patch
+from decimal import Decimal
+from datetime import datetime
+from src.web.app import create_app
+
+
+class TestAdminTransactionHistory:
+    
+    @pytest.fixture
+    def client(self):
+        user_repo = Mock()
+        self.receipt_repo = Mock()
+        coupon_repo = Mock()
+        ocr_service = Mock()
+        store_repo = Mock()
+        coupon_service = Mock()
+        
+        app = create_app(
+            user_repo=user_repo,
+            receipt_repo=self.receipt_repo,
+            coupon_repo=coupon_repo,
+            ocr_service=ocr_service,
+            store_repo=store_repo,
+            coupon_service=coupon_service
+        )
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            yield client
+    
+    def test_should_display_all_transactions(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+        
+        receipt1 = Mock()
+        receipt1.user_name = 'User1'
+        receipt1.store_name = 'Store1'
+        receipt1.total_amount = Decimal('50.0')
+        receipt1.date = datetime(2023, 1, 1)
+        receipt2 = Mock()
+        receipt2.user_name = 'User2'
+        receipt2.store_name = 'Store2'
+        receipt2.total_amount = Decimal('75.0')
+        receipt2.date = datetime(2023, 1, 2)
+        self.receipt_repo.list_all.return_value = [receipt1, receipt2]
+        
+        response = client.get('/admin/transactions')
+        assert response.status_code == 200
+        content = response.get_data(as_text=True)
+        assert 'User1' in content
+        assert 'User2' in content
+        assert 'Store1' in content
+        assert 'Store2' in content
+        assert '50.0' in content
+        assert '75.0' in content
+    
+    def test_should_filter_transactions_by_user(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+        
+        receipt1 = Mock()
+        receipt1.user_name = 'User1'
+        receipt1.store_name = 'Store1'
+        receipt1.total_amount = Decimal('50.0')
+        receipt1.date = datetime(2023, 1, 1)
+        self.receipt_repo.find_by_user_id.return_value = [receipt1]
+        
+        response = client.get('/admin/transactions?user_id=user1')
+        assert response.status_code == 200
+        self.receipt_repo.find_by_user_id.assert_called_once_with('user1')
+    
+    def test_should_filter_transactions_by_date(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+        
+        receipt1 = Mock()
+        receipt1.user_name = 'User1'
+        receipt1.store_name = 'Store1'
+        receipt1.total_amount = Decimal('50.0')
+        receipt1.date = datetime(2023, 1, 1)
+        self.receipt_repo.find_by_date_range.return_value = [receipt1]
+        
+        response = client.get('/admin/transactions?start_date=2023-01-01&end_date=2023-01-31')
+        assert response.status_code == 200
+        # The method should be called with datetime objects, but we'll test the call was made
+        self.receipt_repo.find_by_date_range.assert_called_once()
+    
+    def test_should_filter_transactions_by_store(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+        
+        receipt1 = Mock()
+        receipt1.user_name = 'User1'
+        receipt1.store_name = 'Store1'
+        receipt1.total_amount = Decimal('50.0')
+        receipt1.date = datetime(2023, 1, 1)
+        self.receipt_repo.find_by_store_name.return_value = [receipt1]
+        
+        response = client.get('/admin/transactions?store_name=Store1')
+        assert response.status_code == 200
+        self.receipt_repo.find_by_store_name.assert_called_once_with('Store1')

--- a/tests/admin/test_admin_user_management.py
+++ b/tests/admin/test_admin_user_management.py
@@ -1,0 +1,86 @@
+import pytest
+from unittest.mock import Mock, patch
+from decimal import Decimal
+from src.web.app import create_app
+
+
+class TestAdminUserManagement:
+    
+    @pytest.fixture
+    def client(self):
+        self.user_repo = Mock()
+        receipt_repo = Mock()
+        coupon_repo = Mock()
+        ocr_service = Mock()
+        store_repo = Mock()
+        coupon_service = Mock()
+        
+        app = create_app(
+            user_repo=self.user_repo,
+            receipt_repo=receipt_repo,
+            coupon_repo=coupon_repo,
+            ocr_service=ocr_service,
+            store_repo=store_repo,
+            coupon_service=coupon_service
+        )
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            yield client
+    
+    def test_should_display_all_users_in_admin(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+        
+        user1 = Mock()
+        user1.name = 'User1'
+        user1.deposit = Decimal('100.0')
+        user2 = Mock()
+        user2.name = 'User2'
+        user2.deposit = Decimal('200.0')
+        self.user_repo.list_all.return_value = [user1, user2]
+        
+        response = client.get('/admin/users')
+        assert response.status_code == 200
+        content = response.get_data(as_text=True)
+        assert 'User1' in content
+        assert 'User2' in content
+        assert '100.0' in content
+        assert '200.0' in content
+    
+    def test_should_allow_admin_to_create_user(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+        
+        response = client.post('/admin/users', data={
+            'name': 'New User',
+            'deposit': '500.0'
+        })
+        assert response.status_code == 302
+        self.user_repo.save.assert_called_once()
+    
+    def test_should_allow_admin_to_add_deposit(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+            
+        user = Mock()
+        user.deposit = Decimal('100.0')
+        self.user_repo.get_by_id.return_value = user
+        
+        response = client.post('/admin/users/user1/add-deposit', data={
+            'amount': '50.0'
+        })
+        assert response.status_code == 302
+        user.add_deposit.assert_called_once_with(Decimal('50.0'))
+        self.user_repo.save.assert_called_once_with(user)
+    
+    def test_should_allow_admin_to_delete_user(self, client):
+        # Log in as admin
+        with client.session_transaction() as sess:
+            sess['admin_logged_in'] = True
+            
+        response = client.post('/admin/users/user1/delete')
+        assert response.status_code == 302
+        self.user_repo.delete.assert_called_once_with('user1')


### PR DESCRIPTION
web: escape store name, tolerate mixed receipt fields with fallback lookup
store-repo: propagate Store.id in returns and add partial update API
admin-stores: toggle/set-goal update persistence without re-adding docs
receipts: save denormalized user/store names and total_amount for views